### PR TITLE
Enumerated update statuses instead of binary

### DIFF
--- a/modules/update_helper_checklist/update_helper_checklist.module
+++ b/modules/update_helper_checklist/update_helper_checklist.module
@@ -14,6 +14,11 @@ use Drupal\update_helper_checklist\UpdateChecklist;
 use Symfony\Component\Yaml\Yaml;
 use Drupal\update_helper_checklist\Entity\Update;
 
+const CONFIG_NOT_FOUND = 0;
+const CONFIG_ALREADY_APPLIED = 1;
+const CONFIG_NOT_EXPECTED = 2;
+const CONFIG_APPLIED_SUCCESSFULLY = 3;
+
 /**
  * Implements hook_checklistapi_checklist_info().
  */
@@ -62,10 +67,10 @@ function _update_helper_checklist_checklistapi_checklist_items() {
           $entry = Update::load($update_key);
 
           $status = ($entry && $entry->wasSuccessfulByHook()) ? TRUE : FALSE;
-          if ($status && !empty($update['#description_successful'])) {
+          if ($entry && $status && !empty($update['#description_successful'])) {
             $update['#description'] .= $update['#description_successful'];
           }
-          elseif (!$status && !empty($update['#description_failed'])) {
+          elseif ($entry && !$status && !empty($update['#description_failed'])) {
             $update['#description'] .= $update['#description_failed'];
           }
         }
@@ -107,6 +112,7 @@ function _update_helper_checklist_checklistapi_checklist_items() {
 function update_helper_checklist_modules_installed(array $modules) {
   /** @var \Drupal\Core\Extension\ModuleHandler $module_handler */
   $module_handler = \Drupal::service('module_handler');
+  $updateHelper = \Drupal::service('update_helper.updater');
 
   $modules_checklist = [];
   $module_directories = $module_handler->getModuleDirectories();
@@ -120,6 +126,10 @@ function update_helper_checklist_modules_installed(array $modules) {
     foreach ($updates_checklist as $version_items) {
       foreach ($version_items as $update_hook_name => $checklist_definition) {
         if (is_array($checklist_definition)) {
+
+          $status = $updateHelper->checkUpdate($module_name, $update_hook_name);
+          if ($status != CONFIG_ALREADY_APPLIED && $status != CONFIG_APPLIED_SUCCESSFULLY) continue;
+
           if (!isset($modules_checklist[$module_name])) {
             $modules_checklist[$module_name] = [];
           }

--- a/modules/update_helper_checklist/update_helper_checklist.module
+++ b/modules/update_helper_checklist/update_helper_checklist.module
@@ -13,11 +13,7 @@ use Drupal\Core\Url;
 use Drupal\update_helper_checklist\UpdateChecklist;
 use Symfony\Component\Yaml\Yaml;
 use Drupal\update_helper_checklist\Entity\Update;
-
-const CONFIG_NOT_FOUND = 0;
-const CONFIG_ALREADY_APPLIED = 1;
-const CONFIG_NOT_EXPECTED = 2;
-const CONFIG_APPLIED_SUCCESSFULLY = 3;
+use Drupal\update_helper\Updater;
 
 /**
  * Implements hook_checklistapi_checklist_info().
@@ -128,7 +124,7 @@ function update_helper_checklist_modules_installed(array $modules) {
         if (is_array($checklist_definition)) {
 
           $status = $updateHelper->checkUpdate($module_name, $update_hook_name);
-          if ($status != CONFIG_ALREADY_APPLIED && $status != CONFIG_APPLIED_SUCCESSFULLY) continue;
+          if ($status != Updater::CONFIG_ALREADY_APPLIED && $status != Updater::CONFIG_APPLIED_SUCCESSFULLY) continue;
 
           if (!isset($modules_checklist[$module_name])) {
             $modules_checklist[$module_name] = [];

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -188,6 +188,10 @@ class Updater implements UpdaterInterface {
       return $this->executeConfigurationActions($update_definitions, FALSE, TRUE);
     }
 
+    if (empty($update_definitions) && !empty($modulesInstalled)) {
+      return Updater::MODULES_FOUND;
+    }
+
     return Updater::CONFIG_NOT_FOUND;
   }
 

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -249,7 +249,7 @@ class Updater implements UpdaterInterface {
           break;
 
         case Updater::CONFIG_NOT_EXPECTED:
-          $this->logWarning($this->t('Expected current configuration is modefied, Unable to apply new config @configName.', ['@configName' => $configName]));
+          $this->logWarning($this->t('Expected current configuration for @configName is not matching. Unable to apply new config.', ['@configName' => $configName]));
           break;
 
         case Updater::CONFIG_NOT_FOUND:

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -171,7 +171,9 @@ class Updater implements UpdaterInterface {
     $this->warningCount = 0;
 
     $update_definitions = $this->configHandler->loadUpdate($module, $update_definition_name);
-
+    if (isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS])) {
+      unset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS]);
+    }
     if (!empty($update_definitions)) {
       return $this->executeConfigurationActions($update_definitions, FALSE, TRUE);
     }


### PR DESCRIPTION
Enumerated update statuses instead of binary:

1. CONFIG_NOT_FOUND
2. CONFIG_ALREADY_APPLIED
3. CONFIG_NOT_EXPECTED
4. CONFIG_APPLIED_SUCCESSFULLY

This PR will make the module return more meaning full messages when it fails to apply the config updates.