### PR TITLE
Check for expected_modules before applying updates

### DIFF
--- a/modules/update_helper_checklist/update_helper_checklist.module
+++ b/modules/update_helper_checklist/update_helper_checklist.module
@@ -39,6 +39,7 @@ function update_helper_checklist_checklistapi_checklist_info() {
 function _update_helper_checklist_checklistapi_checklist_items() {
   /** @var \Drupal\Core\Extension\ModuleHandler $module_handler */
   $module_handler = \Drupal::service('module_handler');
+  $updateHelper = \Drupal::service('update_helper.updater');
 
   $module_directories = $module_handler->getModuleDirectories();
 
@@ -57,6 +58,8 @@ function _update_helper_checklist_checklistapi_checklist_items() {
       $version_updates = [];
       foreach ($updates as $update_key => $update) {
         if (is_array($update)) {
+          $neededModules = $updateHelper->checkExpectedModules($module_name, $update_key);
+          if(!empty($neededModules)) continue;
           // Change update key to contain module name.
           $update_key = str_replace('.', '_', $module_name . ':' . $update_key);
           $entry = Update::load($update_key);

--- a/src/UpdateDefinitionInterface.php
+++ b/src/UpdateDefinitionInterface.php
@@ -17,14 +17,21 @@ interface UpdateDefinitionInterface {
   const GLOBAL_ACTIONS = '__global_actions';
 
   /**
+   * Special CUD key used by update helper to make global system conditions.
+   *
+   * Current provided global conditions are "expected_modules".
+   */
+  const GLOBAL_CONDITIONS = '__global_conditions';
+
+  /**
+   * Global condition key for expected modules.
+   */
+  const GLOBAL_CONDITION_EXPECTED_MODULES = 'expected_modules';
+  
+  /**
    * Global action key for installing modules.
    */
   const GLOBAL_ACTION_INSTALL_MODULES = 'install_modules';
-
-  /**
-   * Global action key for expected modules.
-   */
-  const GLOBAL_ACTION_EXPECTED_MODULES = 'expected_modules';
 
   /**
    * Global action key for importing configurations.

--- a/src/UpdateDefinitionInterface.php
+++ b/src/UpdateDefinitionInterface.php
@@ -22,6 +22,11 @@ interface UpdateDefinitionInterface {
   const GLOBAL_ACTION_INSTALL_MODULES = 'install_modules';
 
   /**
+   * Global action key for expected modules.
+   */
+  const GLOBAL_ACTION_EXPECTED_MODULES = 'expected_modules';
+
+  /**
    * Global action key for importing configurations.
    */
   const GLOBAL_ACTION_IMPORT_CONFIGS = 'import_configs';

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -135,6 +135,12 @@ class Updater implements UpdaterInterface {
 
     $update_definitions = $this->configHandler->loadUpdate($module, $update_definition_name);
     if (isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS])) {
+      if(isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_ACTION_EXPECTED_MODULES])){
+        $result = $this->checkExpectedModulesArray($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_ACTION_EXPECTED_MODULES]);
+        if(!empty($result)){
+          return $this->logWarning($this->t('The following module(s) "@neededModules" are required for update @updateName.', ['@neededModules' => implode(", ", $result), '@updateName' => $update_definition_name]));
+        }
+      }
       $this->executeGlobalActions($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS]);
 
       unset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS]);
@@ -169,6 +175,45 @@ class Updater implements UpdaterInterface {
     if (isset($global_actions[UpdateDefinitionInterface::GLOBAL_ACTION_IMPORT_CONFIGS])) {
       $this->importConfigs($global_actions[UpdateDefinitionInterface::GLOBAL_ACTION_IMPORT_CONFIGS]);
     }
+  }
+
+  /**
+   * Check if modules are enabled and installed.
+   *
+   * @param string $module
+   *   Module name where update definition is saved.
+   * @param string $update_definition_name
+   *   Update definition name. Usually same name as update hook.
+   *
+   * @return array
+   *   Returns array needed modules.
+   */
+  public function checkExpectedModules($module, $update_definition_name) {
+    $update_definitions = $this->configHandler->loadUpdate($module, $update_definition_name);
+    if (isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS])) {
+      if(isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_ACTION_EXPECTED_MODULES])){
+        return $this->checkExpectedModulesArray($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_ACTION_EXPECTED_MODULES]);
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Check if modules are enabled and installed.
+   *
+   * @param array $global_actions
+   *   Array with list of expected modules.
+   *
+   * @return array
+   *   Returns array needed modules.
+   */
+  public function checkExpectedModulesArray(array $expected_modules) {
+    $needed_modules = [];
+    $moduleHandler = \Drupal::service('module_handler');
+    foreach ($expected_modules as $expected_module) {
+      if (!$moduleHandler->moduleExists($expected_module)) $needed_modules[] = $expected_module;
+    }
+    return $needed_modules;
   }
 
   /**

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -197,8 +197,8 @@ class Updater implements UpdaterInterface {
   public function checkExpectedModules($module, $update_definition_name) {
     $update_definitions = $this->configHandler->loadUpdate($module, $update_definition_name);
     if (isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS])) {
-      if(isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_ACTION_EXPECTED_MODULES])){
-        return $this->checkExpectedModulesArray($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_ACTION_EXPECTED_MODULES]);
+      if(isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_CONDITION_EXPECTED_MODULES])){
+        return $this->checkExpectedModulesArray($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_CONDITION_EXPECTED_MODULES]);
       }
     }
     return [];

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -134,13 +134,19 @@ class Updater implements UpdaterInterface {
     $this->warningCount = 0;
 
     $update_definitions = $this->configHandler->loadUpdate($module, $update_definition_name);
-    if (isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS])) {
-      if(isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_ACTION_EXPECTED_MODULES])){
-        $result = $this->checkExpectedModulesArray($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS][UpdateDefinitionInterface::GLOBAL_ACTION_EXPECTED_MODULES]);
+
+    if (isset($update_definitions[UpdateDefinitionInterface::GLOBAL_CONDITIONS])) {
+      if(isset($update_definitions[UpdateDefinitionInterface::GLOBAL_CONDITIONS][UpdateDefinitionInterface::GLOBAL_CONDITION_EXPECTED_MODULES])){
+        $result = $this->checkExpectedModulesArray($update_definitions[UpdateDefinitionInterface::GLOBAL_CONDITIONS][UpdateDefinitionInterface::GLOBAL_CONDITION_EXPECTED_MODULES]);
         if(!empty($result)){
           return $this->logWarning($this->t('The following module(s) "@neededModules" are required for update @updateName.', ['@neededModules' => implode(", ", $result), '@updateName' => $update_definition_name]));
         }
       }
+      unset($update_definitions[UpdateDefinitionInterface::GLOBAL_CONDITIONS]);
+    }
+
+
+    if (isset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS])) {
       $this->executeGlobalActions($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS]);
 
       unset($update_definitions[UpdateDefinitionInterface::GLOBAL_ACTIONS]);


### PR DESCRIPTION
Some updates refer to modules that can be uninstalled in a site, which means that the update is dependent on the existence of certain modules. If the module is not installed, skip the update (and the checklist entry). Therefore this PR will allow you to add expected_modules check to the global_actions as follows:

__global_actions: 
    expected_modules: 
        - module_name1
        - module_name2