### PR TITLE
Issue #3105560: Remove deprecated code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/console": "~3.4.0 || ^4.4"
     },
     "require-dev": {
-        "drupal/checklistapi": "~1.0"
+        "drupal/checklistapi": "~1.0",
+        "drupal/console": "~1.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,10 @@
         }
     ],
     "require": {
-        "drupal/config_update": "^1.5"
+        "drupal/config_update": "^1.5",
+        "symfony/console": "~3.4.0 || ^4.4"
     },
     "require-dev": {
-	    "drupal/checklistapi": "~1.0"
+        "drupal/checklistapi": "~1.0"
     }
 }

--- a/update_helper.services.yml
+++ b/update_helper.services.yml
@@ -15,3 +15,12 @@ services:
   update_helper.config_exporter:
     class: Drupal\update_helper\ConfigExporter
     arguments: ['@config_update.extension_storage', '@config_update.extension_optional_storage', '@serialization.yaml']
+
+  update_helper.console_output:
+    class: Symfony\Component\Console\Output\StreamOutput
+    arguments: ['@stream']
+
+
+  update_helper.console_logger:
+    class: Symfony\Component\Console\Logger\ConsoleLogger
+    arguments: []

--- a/update_helper.services.yml
+++ b/update_helper.services.yml
@@ -15,12 +15,3 @@ services:
   update_helper.config_exporter:
     class: Drupal\update_helper\ConfigExporter
     arguments: ['@config_update.extension_storage', '@config_update.extension_optional_storage', '@serialization.yaml']
-
-  update_helper.console_output:
-    class: Symfony\Component\Console\Output\StreamOutput
-    arguments: ['@stream']
-
-
-  update_helper.console_logger:
-    class: Symfony\Component\Console\Logger\ConsoleLogger
-    arguments: []


### PR DESCRIPTION
Idea is to switch from drush logger to symfony console logger and be more independant.

Drush is using Robo logger now and symfony console logger is available in Drupal 8 and Drupal 9, so we are compatible for both major versions.

**Testing**

1. Create update hook with several logging messages with few different levels (fe. warn, info, error)
2. Run this update hook with Drush 9 and Drush 8 - check output
3. Run this update hook with Drush 9 and Drush 8 with new code - check output

If formatting is off too much and readabiliy is decreased, then we should think about different formatting or another logger.