### PR TITLE
Issue #3089823: Delete action is not performed if not after change action

### DIFF
--- a/src/ConfigExporter.php
+++ b/src/ConfigExporter.php
@@ -75,7 +75,7 @@ class ConfigExporter {
       if ($file_data) {
         $full_file_path = $config_storage->getFilePath($config_full_name);
 
-        return file_put_contents($full_file_path, $this->serializer->encode($data)) !== FALSE;
+        return file_put_contents($full_file_path, $this->serializer::encode($data)) !== FALSE;
       }
     }
 

--- a/src/ConfigHandler.php
+++ b/src/ConfigHandler.php
@@ -262,9 +262,9 @@ class ConfigHandler {
    */
   protected function getUpdateConfig(array $diffs) {
     $list_update = [
+      'delete' => [],
       'add' => [],
       'change' => [],
-      'delete' => [],
     ];
 
     foreach ($diffs as $diff_op) {

--- a/src/ConfigHandler.php
+++ b/src/ConfigHandler.php
@@ -153,7 +153,7 @@ class ConfigHandler {
       $this->exportConfigurations(array_keys($update_patch));
     }
 
-    return $update_patch ? $this->serializer->encode($update_patch) : FALSE;
+    return $update_patch ? $this->serializer::encode($update_patch) : FALSE;
   }
 
   /**

--- a/tests/src/Kernel/ConfigHandlerTest.php
+++ b/tests/src/Kernel/ConfigHandlerTest.php
@@ -51,16 +51,16 @@ class ConfigHandlerTest extends KernelTestBase {
       '    status: false' . PHP_EOL .
       '    type: text' . PHP_EOL .
       '  update_actions:' . PHP_EOL .
+      '    delete:' . PHP_EOL .
+      '      lost_config: text' . PHP_EOL .
+      '      settings:' . PHP_EOL .
+      '        max_length: 123' . PHP_EOL .
       '    add:' . PHP_EOL .
       '      cardinality: 1' . PHP_EOL .
       '    change:' . PHP_EOL .
       '      settings: {  }' . PHP_EOL .
       '      status: true' . PHP_EOL .
-      '      type: text_with_summary' . PHP_EOL .
-      '    delete:' . PHP_EOL .
-      '      lost_config: text' . PHP_EOL .
-      '      settings:' . PHP_EOL .
-      '        max_length: 123' . PHP_EOL;
+      '      type: text_with_summary' . PHP_EOL;
   }
 
   /**

--- a/tests/src/Kernel/UpdaterTest.php
+++ b/tests/src/Kernel/UpdaterTest.php
@@ -131,6 +131,28 @@ class UpdaterTest extends KernelTestBase {
     /** @var \Drupal\Core\Serialization\Yaml $yml_serializer */
     $yml_serializer = \Drupal::service('serialization.yaml');
     file_put_contents($this->configDir . '/install/tour.tour.tour-update-helper-test.yml', $yml_serializer->encode($tour_config));
+
+    /** @var \Drupal\update_helper\ConfigHandler $config_handler */
+    $config_handler = \Drupal::service('update_helper.config_handler');
+
+    // Create update configuration for testExecuteUpdate.
+    $patch_file_path = $config_handler->getPatchFile('update_helper', 'test_updater', TRUE);
+    file_put_contents($patch_file_path, $yml_serializer->encode($this->getUpdateDefinition()));
+
+    // Create update configuration for testOnlyDeleteUpdate.
+    $patch_file_path = $config_handler->getPatchFile('update_helper', 'test_updater_only_delete', TRUE);
+    file_put_contents($patch_file_path, $yml_serializer->encode(
+      [
+        'field.storage.node.body' => [
+          'expected_config' => [],
+          'update_actions' => [
+            'delete' => [
+              'lost_config' => 'text',
+            ],
+          ],
+        ],
+      ]
+    ));
   }
 
   /**
@@ -145,6 +167,7 @@ class UpdaterTest extends KernelTestBase {
 
     // Remove configuration update definition.
     unlink($config_dir . '/update/test_updater.yml');
+    unlink($config_dir . '/update/test_updater_only_delete.yml');
     rmdir($config_dir . '/update');
 
     rmdir($config_dir);
@@ -178,15 +201,6 @@ class UpdaterTest extends KernelTestBase {
     /** @var \Drupal\update_helper\Updater $update_helper */
     $update_helper = \Drupal::service('update_helper.updater');
 
-    /** @var \Drupal\Core\Serialization\Yaml $yml_serializer */
-    $yml_serializer = \Drupal::service('serialization.yaml');
-
-    /** @var \Drupal\update_helper\ConfigHandler $config_handler */
-    $config_handler = \Drupal::service('update_helper.config_handler');
-
-    $patch_file_path = $config_handler->getPatchFile('update_helper', 'test_updater', TRUE);
-    file_put_contents($patch_file_path, $yml_serializer->encode($this->getUpdateDefinition()));
-
     $this->assertFalse($this->moduleHandler->moduleExists('help'), 'Module "help" should not be installed.');
 
     // Create some configuration file for tour, so that it can be imported.
@@ -200,6 +214,33 @@ class UpdaterTest extends KernelTestBase {
     $this->assertEquals($expected_config_data, $config_factory->get('field.storage.node.body')->get());
     $this->assertTrue($this->moduleHandler->moduleExists('help'), 'Module "help" should be installed.');
     $this->assertEquals('tour-update-helper-test', $this->container->get('config.factory')->get('tour.tour.tour-update-helper-test')->get('id'), 'Tour configuration should exist.');
+  }
+
+  /**
+   * Test issue with using delete action without expected.
+   */
+  public function testOnlyDeleteUpdate() {
+    /** @var \Drupal\config_update\ConfigRevertInterface $config_reverter */
+    $config_reverter = \Drupal::service('config_update.config_update');
+    $config_reverter->import('field_storage_config', 'node.body');
+
+    $config = $this->config('field.storage.node.body');
+    $expected_config_data = $config->get();
+
+    $config_data = $expected_config_data;
+    $config_data['lost_config'] = 'text';
+
+    $config->setData($config_data)->save(TRUE);
+
+    /** @var \Drupal\update_helper\Updater $update_helper */
+    $update_helper = \Drupal::service('update_helper.updater');
+
+    // Ensure that configuration had new values.
+    $this->assertEquals('text', $this->config('field.storage.node.body')->get('lost_config'));
+
+    // Execute update and validate new state.
+    $update_helper->executeUpdate('update_helper', 'test_updater_only_delete');
+    $this->assertEquals($expected_config_data, $this->config('field.storage.node.body')->get());
   }
 
 }

--- a/tests/src/Kernel/UpdaterTest.php
+++ b/tests/src/Kernel/UpdaterTest.php
@@ -130,18 +130,18 @@ class UpdaterTest extends KernelTestBase {
 
     /** @var \Drupal\Core\Serialization\Yaml $yml_serializer */
     $yml_serializer = \Drupal::service('serialization.yaml');
-    file_put_contents($this->configDir . '/install/tour.tour.tour-update-helper-test.yml', $yml_serializer->encode($tour_config));
+    file_put_contents($this->configDir . '/install/tour.tour.tour-update-helper-test.yml', $yml_serializer::encode($tour_config));
 
     /** @var \Drupal\update_helper\ConfigHandler $config_handler */
     $config_handler = \Drupal::service('update_helper.config_handler');
 
     // Create update configuration for testExecuteUpdate.
     $patch_file_path = $config_handler->getPatchFile('update_helper', 'test_updater', TRUE);
-    file_put_contents($patch_file_path, $yml_serializer->encode($this->getUpdateDefinition()));
+    file_put_contents($patch_file_path, $yml_serializer::encode($this->getUpdateDefinition()));
 
     // Create update configuration for testOnlyDeleteUpdate.
     $patch_file_path = $config_handler->getPatchFile('update_helper', 'test_updater_only_delete', TRUE);
-    file_put_contents($patch_file_path, $yml_serializer->encode(
+    file_put_contents($patch_file_path, $yml_serializer::encode(
       [
         'field.storage.node.body' => [
           'expected_config' => [],


### PR DESCRIPTION
Problem is described here: https://www.drupal.org/project/update_helper/issues/3089823

PR includes the following:
- test for the described problem
- handling of applied configuration changes. First, all changes will be applied and then new configuration will be verified against active configuration and only if it's exactly same, it will be marked as update was already successfully applied.